### PR TITLE
Correction-for-Mormon-Trails-Booth-404-error

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -180,14 +180,13 @@
                     </article>
                 </a>
 
-                <a href="./blog/2025-03-08-rootstech-mormon-trails.html" class="group block w-full">
+                <a href="./blog/2025-03-08-rootstech-mormon_trails.html" class="group block w-full">
                     <article class="border shadow rounded flex flex-col items-center justify-center space-y-2">
                         <img src="./images/mtabooth.jpg" alt="Mormon Trails Rootstech Booth 2025" class="w-full h-48 object-cover rounded">
                         <h3 class="text-lg font-bold text-gray-900 pt-4 px-4">A New Bill for The Mormon Trails!</h3>
                         <p class="text-sm text-gray-700 px-4"><time datetime="2025-01-01">March 8, 2025</time></p>
                         <p class="text-gray-800 text-sm line-clamp-2 px-4">
-                            The future of The Mormon Battalion Trail and its possibility of obtaining historic trail status rests in the hands of the National Mormon Trails Association being able to push a new bill through congress.
-                        </p>
+                            The future of The Mormon Battalion Trail and its possibility of obtaining historic trail status rests in the hands of the National Mormon Trails Association being able to push a new bill through congress.</p>
                         <p class="text-blue-500 group-hover:text-blue-800 pb-4">Read More</p>
                     </article>
                 </a>


### PR DESCRIPTION
I noticed a 404 error on the one blog post.  Found I'd put a - instead of an _ in the name.  That seemed to fix it.